### PR TITLE
Enforce a single language across the league

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN go build
 
 ENV CONTESTANTS={}
 ENV PROXY=false
+ENV LANGUAGE=en-US
 EXPOSE 8080
 
-ENTRYPOINT ./alterna-freshness-league --proxy=${PROXY} --league=${CONTESTANTS}
+ENTRYPOINT ./alterna-freshness-league --proxy=${PROXY} --league=${CONTESTANTS} --language=${LANGUAGE}

--- a/README.md
+++ b/README.md
@@ -49,4 +49,6 @@ Or, to run a proxy:
         Port to bind to (default "8080")
   -proxy
         Start in proxy mode
+  -language
+        Language to use for the league (default "en-US")
  ```

--- a/datahandling/splatnet_login.go
+++ b/datahandling/splatnet_login.go
@@ -3,6 +3,7 @@ package datahandling
 import (
 	"bytes"
 	"encoding/json"
+	"flag"
 	"fmt"
 	"net/http"
 )
@@ -42,7 +43,11 @@ type iminkApiResponse struct {
 	Timestamp int    `json:"timestamp"`
 }
 
+var leagueLanguage string
+
 func splatnetLogin(contestant *Contestant, nsoAppVersion string, webveiwVersion string, client *http.Client) (*splatnetAccount, error) {
+	leagueLanguage = flag.Lookup("language").Value.(flag.Getter).Get().(string)
+
 	nintendoTokenResponse, err := getNintendoAccessToken(contestant, client)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get nintendoTokenResponse: %w", err)
@@ -80,14 +85,14 @@ func splatnetLogin(contestant *Contestant, nsoAppVersion string, webveiwVersion 
 
 	graphQlHeader := map[string]string{
 		"Authorization":    fmt.Sprintf("Bearer %s", bulletTokenResponse.BulletToken),
-		"Accept-Language":  nintendoUserInfo.Language,
+		"Accept-Language":  leagueLanguage,
 		"User-Agent":       "Mozilla/5.0 (Linux; Android 11; Pixel 5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/94.0.4606.61 Mobile Safari/537.36",
 		"X-Web-View-Ver":   webveiwVersion,
 		"Content-Type":     "application/json",
 		"Accept":           "*/*",
 		"Origin":           "https://api.lp1.av5ja.srv.nintendo.net",
 		"X-Requested-With": "com.nintendo.znca",
-		"Referer":          fmt.Sprintf("https://api.lp1.av5ja.srv.nintendo.net/?lang=%s&na_country=%s&na_lang=%s", nintendoUserInfo.Language, nintendoUserInfo.Country, nintendoUserInfo.Language),
+		"Referer":          fmt.Sprintf("https://api.lp1.av5ja.srv.nintendo.net/?lang=%s&na_country=%s&na_lang=%s", leagueLanguage, nintendoUserInfo.Country, leagueLanguage),
 	}
 
 	return &splatnetAccount{
@@ -105,7 +110,7 @@ func getBulletToken(nintendoUserInfo *nintendoApiUserInfoResponse, webveiwVersio
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Accept-Language", nintendoUserInfo.Language)
+	req.Header.Set("Accept-Language", leagueLanguage)
 	req.Header.Set("User-Agent", "Mozilla/5.0 (Linux; Android 11; Pixel 5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/94.0.4606.61 Mobile Safari/537.36")
 	req.Header.Set("X-Web-View-Ver", webveiwVersion)
 	req.Header.Set("X-NACOUNTRY", nintendoUserInfo.Country)
@@ -170,7 +175,7 @@ func getSplatoonAccessToken(iminkResponse1 *iminkApiResponse, nintendoUserInfo *
 	body := map[string]interface{}{
 		"parameter": map[string]interface{}{
 			"f":          iminkResponse1.Ftoken,
-			"language":   nintendoUserInfo.Language,
+			"language":   leagueLanguage,
 			"naBirthday": nintendoUserInfo.Birthday,
 			"naCountry":  nintendoUserInfo.Country,
 			"naIdToken":  nintendoTokenResponse.IdToken,

--- a/main.go
+++ b/main.go
@@ -15,6 +15,7 @@ func main() {
 	port := flag.String("port", "8080", "Port to bind to")
 	proxy := flag.Bool("proxy", false, "Start in proxy mode")
 	flag.Var(&league, "league", "Contestants json string, tries to read 'contestants.json' file if not set")
+	flag.String("language", "en-US", "Language to use for the league")
 	flag.Parse()
 
 	if cmp.Equal(league, datahandling.League{}) {


### PR DESCRIPTION
This pull request adds a new flag, `language`, this makes the server use the same language for all local contestants.